### PR TITLE
Enable ingres for ghost

### DIFF
--- a/releases/ghost.yaml
+++ b/releases/ghost.yaml
@@ -29,3 +29,8 @@ spec:
       master:
         persistence:
           enabled: false
+    ingress:
+      enabled: true
+      annotations:
+        kubernetes.io/ingress.class: traefik
+      


### PR DESCRIPTION
This commit enables ingress with traefik for ghost.